### PR TITLE
Add support for QUIC as communication pipeline

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,18 +37,6 @@ resource "azurerm_network_security_group" "mgmt_plane" {
   }
 
   security_rule {
-    name                       = "stc-portgroup"
-    priority                   = 120
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "51204"
-    source_address_prefixes    = var.ingress_cidr_blocks
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
     name                       = "stc-chassis-ready"
     priority                   = 130
     direction                  = "Inbound"
@@ -61,12 +49,61 @@ resource "azurerm_network_security_group" "mgmt_plane" {
   }
 
   security_rule {
+    name                       = "stc-chassis-ready-QUIC"
+    priority                   = 130
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "40005"
+    source_address_prefixes    = var.ingress_cidr_blocks
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "stc-portgroup"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "51204"
+    source_address_prefixes    = var.ingress_cidr_blocks
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "stc-portgroup-QUIC"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "51204"
+    source_address_prefixes    = var.ingress_cidr_blocks
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
     name                       = "bll-ephemeral"
     description                = "All outbound traffic back to BLL"
     priority                   = 101
     direction                  = "Outbound"
     access                     = "Allow"
     protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "49100-65535"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "bll-ephemeral-QUIC"
+    description                = "All outbound traffic back to BLL"
+    priority                   = 101
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
     source_port_range          = "*"
     destination_port_range     = "49100-65535"
     source_address_prefix      = "*"

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_network_security_group" "mgmt_plane" {
 
   security_rule {
     name                       = "stc-chassis-ready-QUIC"
-    priority                   = 130
+    priority                   = 131
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Udp"
@@ -74,7 +74,7 @@ resource "azurerm_network_security_group" "mgmt_plane" {
 
   security_rule {
     name                       = "stc-portgroup-QUIC"
-    priority                   = 120
+    priority                   = 121
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Udp"
@@ -100,7 +100,7 @@ resource "azurerm_network_security_group" "mgmt_plane" {
   security_rule {
     name                       = "bll-ephemeral-QUIC"
     description                = "All outbound traffic back to BLL"
-    priority                   = 101
+    priority                   = 102
     direction                  = "Outbound"
     access                     = "Allow"
     protocol                   = "Udp"


### PR DESCRIPTION
Add QUIC's UDP port and the UDP ports for BLL comms to the security group with different priorities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-Terraform-Modules/terraform-azurerm-stcv/8)
<!-- Reviewable:end -->
